### PR TITLE
fix: update kubelet checks via kubelet config resource

### DIFF
--- a/job.yaml
+++ b/job.yaml
@@ -14,7 +14,7 @@ spec:
         - name: node-collector
           image: ghcr.io/aquasecurity/node-collector:0.0.9
           command: ["node-collector"]
-          args: ["k8s","--node","minikube"]
+          args: ["k8s", "--node", "minikube"]
           volumeMounts:
             - name: var-lib-etcd
               mountPath: /var/lib/etcd

--- a/job.yaml
+++ b/job.yaml
@@ -14,6 +14,7 @@ spec:
         - name: node-collector
           image: ghcr.io/aquasecurity/node-collector:0.0.9
           command: ["node-collector"]
+          args: ["k8s","--node","minikube"]
           volumeMounts:
             - name: var-lib-etcd
               mountPath: /var/lib/etcd

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -11,6 +11,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("output", "o", "json", "Output format. One of table|json")
 	rootCmd.PersistentFlags().StringP("spec", "s", "cis", " spec name.  default: cis")
 	rootCmd.PersistentFlags().StringP("version", "v", "1.23", "spec version.  default: 1.23")
+	rootCmd.PersistentFlags().StringP("node", "n", "minikube", "node name.  default: minikube")
 }
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
## Description
fix: update  kubelet checks via kubelet  config resource

## Related issues
- Related https://github.com/aquasecurity/trivy-operator/issues/1687
- Related https://github.com/aquasecurity/trivy-operator/issues/1592

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/k8s-node-collector/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/k8s-node-collector/tree/main/docs) with the relevant information (if needed).
